### PR TITLE
ci: add auto merge action for release PR

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,20 @@
+name: Enable automerge on release PRs
+
+on:
+  pull_request_target:
+  push:
+    branches:
+      - "release-please-*"
+
+jobs:
+  auto-merge-release:
+    name: Enable automerge on release PRs
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease:pending')
+    steps:
+      - name: Enable automerge on dependabot PRs
+        uses: daneden/enable-automerge-action@v1
+        with:
+          github-token: ${{ secrets.CI }}
+          allowed-author: "github-actions[bot]"
+          merge-method: SQUASH


### PR DESCRIPTION
- Added auto merge release yml config file. Filtered to job only run on the `release-please` branches and only if the PR has the tag `autorelease:pending`