### PR TITLE
fix: change validation from `contains` to `startsWith`

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,7 +10,7 @@ jobs:
   auto-merge-release:
     name: Enable automerge on release PRs
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: startsWith(github.event.pull_request.labels.*.name, 'autorelease:')
     steps:
       - name: Enable automerge on dependabot PRs
         uses: daneden/enable-automerge-action@v1


### PR DESCRIPTION
Added change because the contains was throwing wrong sintax error with a label that had spaces on it.