### PR TITLE
ci: use github cli to enable auto merge on release PRs

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'autorelease')
     steps:
-      - name: Enable automerge on dependabot PRs
-        uses: daneden/enable-automerge-action@v1
-        with:
-          github-token: ${{ secrets.CI }}
-          allowed-author: "github-actions[bot]"
-          merge-method: SQUASH
+      - name: Enable automerge on release PR
+        run: gh pr merge --squash --auto "1"
+        env:
+          GH_TOKEN: ${{ secrets.CI }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -11,6 +11,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'autorelease')
     steps:
       - name: Enable automerge on release PR
-        run: gh pr merge --squash --auto "1"
+        run: gh pr merge --squash --auto "{{ github.event.number }}"
         env:
           GH_TOKEN: ${{ secrets.CI }}


### PR DESCRIPTION
- Removed custom action because it was failing internally. There is an issue open about it: https://github.com/daneden/enable-automerge-action/issues/120
- Replaced by usage of GH CLI directly