### PR TITLE
ci: remove  event `pull_request`

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,8 +1,6 @@
 name: Enable automerge on release PRs
 
 on:
-  pull_request:
-    types: [labeled]
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 


### PR DESCRIPTION
- removed event `pull_request` as it was triggering the action to be running twice